### PR TITLE
feat!: ability to rename pinned folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 #### Breaking changes due to new features and updated configuration
 - Added `save_extensions` and `default_save_extension` to `FileDialogConfig` [#248](https://github.com/jannistpl/egui-file-dialog/pull/248)
 - Added `save_extension_any` to `FileDialogLabels` [#248](https://github.com/jannistpl/egui-file-dialog/pull/248)
+- Added `rename_pinned_folder` to `FileDialogLabels` [#258](https://github.com/jannistpl/egui-file-dialog/pull/258)
+- Changed `FileDialogStorage::pinned_folders` from `Vec<DirectoryEntry>` to `Vec<PinnedFolder>` [#258](https://github.com/jannistpl/egui-file-dialog/pull/258)
 
 ### ✨ Features
 
@@ -14,6 +16,7 @@
 - Added file extensions and filters when saving a file using `FileDialog::add_save_extension`, `FileDialogConfig::add_save_extension` and `FileDialog::default_save_extension` [#248](https://github.com/fluxxcode/egui-file-dialog/pull/248)
 - Added ability to open path context menu from a segment inside the navigation bar [#253](https://github.com/fluxxcode/egui-file-dialog/pull/253)
 - Added `FileDialog::set_operation_id` to set the ID of the operation for which the dialog is currently being used after opening it [#257](https://github.com/jannistpl/egui-file-dialog/pull/257)
+- Added ability to rename a pinnend folder via its context menu [#258](https://github.com/jannistpl/egui-file-dialog/pull/258)
 
 ### ☢️ Deprecated
 

--- a/examples/multilingual.rs
+++ b/examples/multilingual.rs
@@ -39,6 +39,7 @@ fn get_labels_german() -> FileDialogLabels {
 
         pin_folder: "📌 Ordner anheften".to_string(),
         unpin_folder: "✖ Ordner loslösen".to_string(),
+        rename_pinned_folder: "✏ Ordner umbenennen".to_string(),
 
         selected_directory: "Ausgewählter Ordner:".to_string(),
         selected_file: "Ausgewählte Datei:".to_string(),

--- a/src/config/labels.rs
+++ b/src/config/labels.rs
@@ -80,7 +80,7 @@ pub struct FileDialogLabels {
     pub pin_folder: String,
     /// Text used for the option to unpin a folder.
     pub unpin_folder: String,
-    /// Text user for the option to rename a pinned folder.
+    /// Text used for the option to rename a pinned folder.
     pub rename_pinned_folder: String,
 
     // ------------------------------------------------------------------------

--- a/src/config/labels.rs
+++ b/src/config/labels.rs
@@ -80,6 +80,8 @@ pub struct FileDialogLabels {
     pub pin_folder: String,
     /// Text used for the option to unpin a folder.
     pub unpin_folder: String,
+    /// Text user for the option to rename a pinned folder.
+    pub rename_pinned_folder: String,
 
     // ------------------------------------------------------------------------
     // Bottom panel:
@@ -150,8 +152,9 @@ impl Default for FileDialogLabels {
             pictures_dir: "🖼  Pictures".to_string(),
             videos_dir: "🎞  Videos".to_string(),
 
-            pin_folder: "📌 Pin folder".to_string(),
-            unpin_folder: "✖ Unpin folder".to_string(),
+            pin_folder: "📌 Pin".to_string(),
+            unpin_folder: "✖ Unpin".to_string(),
+            rename_pinned_folder: "✏ Rename".to_string(),
 
             selected_directory: "Selected directory:".to_string(),
             selected_file: "Selected file:".to_string(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,12 +10,31 @@ use std::sync::Arc;
 
 use crate::{FileSystem, NativeFileSystem};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct PinnedFolder {
+    pub path: PathBuf,
+    pub label: String,
+}
+
+impl PinnedFolder {
+    pub fn from_path(path: PathBuf) -> Self {
+        let label = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned();
+
+        Self { path, label }
+    }
+}
+
 /// Contains data of the `FileDialog` that should be stored persistently.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FileDialogStorage {
     /// The folders the user pinned to the left sidebar.
-    pub pinned_folders: Vec<PathBuf>,
+    pub pinned_folders: Vec<PinnedFolder>,
     /// If hidden files and folders should be listed inside the directory view.
     pub show_hidden: bool,
     /// If system files should be listed inside the directory view.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use crate::{FileSystem, NativeFileSystem};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct PinnedFolder {
     pub path: PathBuf,

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1770,14 +1770,25 @@ impl FileDialog {
 
     fn ui_update_pinned_folder_rename(&mut self, ui: &mut egui::Ui) {
         if let Some(r) = &mut self.rename_pinned_folder {
-            let re = ui.text_edit_singleline(&mut r.label);
+            let id = self.window_id.with("pinned_folder_rename").with(&r.path);
+            let mut output = egui::TextEdit::singleline(&mut r.label)
+                .id(id)
+                .cursor_at_end(true)
+                .show(ui);
 
             if self.renamed_pinned_folder_request_focus {
-                re.request_focus();
+                output.state.cursor.set_char_range(Some(CCursorRange::two(
+                    CCursor::new(0),
+                    CCursor::new(r.label.chars().count()),
+                )));
+                output.state.store(ui.ctx(), output.response.id);
+
+                output.response.request_focus();
+
                 self.renamed_pinned_folder_request_focus = false;
             }
 
-            if re.lost_focus() {
+            if output.response.lost_focus() {
                 self.end_rename_pinned_folder();
             }
         }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1762,7 +1762,7 @@ impl FileDialog {
                 pinned.path.as_path(),
             );
 
-            self.ui_update_pinned_folder_context_menu(&response, &pinned);
+            self.ui_update_pinned_folder_context_menu(&response, pinned);
         }
 
         visible
@@ -3039,7 +3039,7 @@ impl FileDialog {
     fn is_pinned_folder_being_renamed(&self, pinned: &PinnedFolder) -> bool {
         self.rename_pinned_folder
             .as_ref()
-            .map_or(false, |p| p.path == pinned.path)
+            .is_some_and(|p| p.path == pinned.path)
     }
 
     fn is_primary_selected(&self, item: &DirectoryEntry) -> bool {

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -163,7 +163,7 @@ pub struct FileDialog {
     rename_pinned_folder: Option<PinnedFolder>,
     /// If the text input of the pinned folder being renamed should request focus in
     /// the next frame.
-    renamed_pinned_folder_request_focus: bool,
+    rename_pinned_folder_request_focus: bool,
 }
 
 /// This tests if file dialog is send and sync.
@@ -243,7 +243,7 @@ impl FileDialog {
             any_focused_last_frame: false,
 
             rename_pinned_folder: None,
-            renamed_pinned_folder_request_focus: false,
+            rename_pinned_folder_request_focus: false,
         }
     }
 
@@ -1776,7 +1776,7 @@ impl FileDialog {
                 .cursor_at_end(true)
                 .show(ui);
 
-            if self.renamed_pinned_folder_request_focus {
+            if self.rename_pinned_folder_request_focus {
                 output.state.cursor.set_char_range(Some(CCursorRange::two(
                     CCursor::new(0),
                     CCursor::new(r.label.chars().count()),
@@ -1785,7 +1785,7 @@ impl FileDialog {
 
                 output.response.request_focus();
 
-                self.renamed_pinned_folder_request_focus = false;
+                self.rename_pinned_folder_request_focus = false;
             }
 
             if output.response.lost_focus() {
@@ -3014,7 +3014,7 @@ impl FileDialog {
     /// Starts to rename a pinned folder by showing the user a text input field.
     fn begin_rename_pinned_folder(&mut self, pinned: PinnedFolder) {
         self.rename_pinned_folder = Some(pinned);
-        self.renamed_pinned_folder_request_focus = true;
+        self.rename_pinned_folder_request_focus = true;
     }
 
     /// Ends the renaming of a pinned folder. This updates the real pinned folder


### PR DESCRIPTION
This PR now allows renaming a pinned folder via the context menu.

Currently saved pinned folders will be deleted, however, because the `FileDialogStorage` has changed and is no longer compatible with previously saved data.

![Screenshot_20250406_204013](https://github.com/user-attachments/assets/122e8ff3-7ac8-4d2f-9d49-4103f8628fb0)

![Screenshot_20250406_204109](https://github.com/user-attachments/assets/d90f983a-c934-4573-8c75-b45870cb1f0e)

Closes #251 