### PR TITLE
refactor!: move storage out of config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### 🚨 Breaking Changes
+- Moved `FileDialogStorage` out of `FileDialogConfig` [#259](https://github.com/jannistpl/egui-file-dialog/pull/259)
 
 #### Breaking changes due to new features and updated configuration
 - Added `save_extensions` and `default_save_extension` to `FileDialogConfig` [#248](https://github.com/jannistpl/egui-file-dialog/pull/248)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,35 +29,6 @@ impl PinnedFolder {
     }
 }
 
-/// Contains data of the `FileDialog` that should be stored persistently.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct FileDialogStorage {
-    /// The folders the user pinned to the left sidebar.
-    pub pinned_folders: Vec<PinnedFolder>,
-    /// If hidden files and folders should be listed inside the directory view.
-    pub show_hidden: bool,
-    /// If system files should be listed inside the directory view.
-    pub show_system_files: bool,
-    /// The last directory the user visited.
-    pub last_visited_dir: Option<PathBuf>,
-    /// The last directory from which the user picked an item.
-    pub last_picked_dir: Option<PathBuf>,
-}
-
-impl Default for FileDialogStorage {
-    /// Creates a new object with default values
-    fn default() -> Self {
-        Self {
-            pinned_folders: Vec::new(),
-            show_hidden: false,
-            show_system_files: false,
-            last_visited_dir: None,
-            last_picked_dir: None,
-        }
-    }
-}
-
 /// Sets which directory is loaded when opening the file dialog.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum OpeningMode {
@@ -105,8 +76,6 @@ pub struct FileDialogConfig {
     // Core:
     /// File system browsed by the file dialog; may be native or virtual.
     pub file_system: Arc<dyn FileSystem + Send + Sync>,
-    /// Persistent data of the file dialog.
-    pub storage: FileDialogStorage,
     /// The labels that the dialog uses.
     pub labels: FileDialogLabels,
     /// Keybindings used by the file dialog.
@@ -263,7 +232,6 @@ impl FileDialogConfig {
     /// Creates a new configuration with default values
     pub fn default_from_filesystem(file_system: Arc<dyn FileSystem + Send + Sync>) -> Self {
         Self {
-            storage: FileDialogStorage::default(),
             labels: FileDialogLabels::default(),
             keybindings: FileDialogKeyBindings::default(),
 
@@ -339,14 +307,6 @@ impl FileDialogConfig {
 }
 
 impl FileDialogConfig {
-    /// Sets the storage used by the file dialog.
-    /// Storage includes all data that is persistently stored between multiple
-    /// file dialog instances.
-    pub fn storage(mut self, storage: FileDialogStorage) -> Self {
-        self.storage = storage;
-        self
-    }
-
     /// Adds a new file filter the user can select from a dropdown widget.
     ///
     /// NOTE: The name must be unique. If a filter with the same name already exists,

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -6,6 +6,20 @@ use std::sync::{mpsc, Arc};
 use std::time::SystemTime;
 use std::{io, thread};
 
+#[derive(Clone, Debug)]
+pub struct DirectoryFilter {
+    /// If files should be included.
+    pub show_files: bool,
+    /// If hidden files and folders should be included.
+    pub show_hidden: bool,
+    /// If system files should be included.
+    pub show_system_files: bool,
+    /// Optional filter to further filter files.
+    pub file_filter: Option<FileFilter>,
+    /// Optional file extension to filter by.
+    pub filter_extension: Option<String>,
+}
+
 /// Contains the metadata of a directory item.
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -211,55 +225,28 @@ impl DirectoryContent {
     pub fn from_path(
         config: &FileDialogConfig,
         path: &Path,
-        include_files: bool,
-        file_filter: Option<&FileFilter>,
-        filter_extension: Option<&str>,
         file_system: Arc<dyn FileSystem + Sync + Send + 'static>,
+        filter: DirectoryFilter,
     ) -> Self {
         if config.load_via_thread {
-            Self::with_thread(
-                config,
-                path,
-                include_files,
-                file_filter,
-                filter_extension,
-                file_system,
-            )
+            Self::with_thread(config, path, file_system, filter)
         } else {
-            Self::without_thread(
-                config,
-                path,
-                include_files,
-                file_filter,
-                filter_extension,
-                &*file_system,
-            )
+            Self::without_thread(config, path, &*file_system, &filter)
         }
     }
 
     fn with_thread(
         config: &FileDialogConfig,
         path: &Path,
-        include_files: bool,
-        file_filter: Option<&FileFilter>,
-        filter_extension: Option<&str>,
         file_system: Arc<dyn FileSystem + Send + Sync + 'static>,
+        filter: DirectoryFilter,
     ) -> Self {
         let (tx, rx) = mpsc::channel();
 
         let c = config.clone();
         let p = path.to_path_buf();
-        let f = file_filter.cloned();
-        let fe = filter_extension.map(str::to_string);
         thread::spawn(move || {
-            let _ = tx.send(load_directory(
-                &c,
-                &p,
-                include_files,
-                f.as_ref(),
-                fe.as_deref(),
-                &*file_system,
-            ));
+            let _ = tx.send(load_directory(&c, &p, &*file_system, &filter));
         });
 
         Self {
@@ -272,19 +259,10 @@ impl DirectoryContent {
     fn without_thread(
         config: &FileDialogConfig,
         path: &Path,
-        include_files: bool,
-        file_filter: Option<&FileFilter>,
-        filter_extension: Option<&str>,
         file_system: &dyn FileSystem,
+        filter: &DirectoryFilter,
     ) -> Self {
-        match load_directory(
-            config,
-            path,
-            include_files,
-            file_filter,
-            filter_extension,
-            file_system,
-        ) {
+        match load_directory(config, path, file_system, filter) {
             Ok(c) => Self {
                 state: DirectoryContentState::Success,
                 content: c,
@@ -399,37 +377,36 @@ fn apply_search_value(entry: &DirectoryEntry, value: &str) -> bool {
 }
 
 /// Loads the contents of the given directory.
+/// TODO: Move filter options to struct
 fn load_directory(
     config: &FileDialogConfig,
     path: &Path,
-    include_files: bool,
-    file_filter: Option<&FileFilter>,
-    filter_extension: Option<&str>,
     file_system: &dyn FileSystem,
+    filter: &DirectoryFilter,
 ) -> io::Result<Vec<DirectoryEntry>> {
     let mut result: Vec<DirectoryEntry> = Vec::new();
     for path in file_system.read_dir(path)? {
         let entry = DirectoryEntry::from_path(config, &path, file_system);
 
-        if !config.storage.show_system_files && entry.is_system_file() {
+        if !filter.show_system_files && entry.is_system_file() {
             continue;
         }
 
-        if !include_files && entry.is_file() {
+        if !filter.show_files && entry.is_file() {
             continue;
         }
 
-        if !config.storage.show_hidden && entry.is_hidden() {
+        if !filter.show_hidden && entry.is_hidden() {
             continue;
         }
 
-        if let Some(file_filter) = file_filter {
+        if let Some(file_filter) = &filter.file_filter {
             if entry.is_file() && !(file_filter.filter)(entry.as_path()) {
                 continue;
             }
         }
 
-        if let Some(ex) = filter_extension {
+        if let Some(ex) = &filter.filter_extension {
             if entry.is_file()
                 && path
                     .extension()

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -377,7 +377,6 @@ fn apply_search_value(entry: &DirectoryEntry, value: &str) -> bool {
 }
 
 /// Loads the contents of the given directory.
-/// TODO: Move filter options to struct
 fn load_directory(
     config: &FileDialogConfig,
     path: &Path,

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,5 +1,7 @@
 mod directory_content;
-pub use directory_content::{DirectoryContent, DirectoryContentState, DirectoryEntry, Metadata};
+pub use directory_content::{
+    DirectoryContent, DirectoryContentState, DirectoryEntry, DirectoryFilter, Metadata,
+};
 
 mod disks;
 pub use disks::{Disk, Disks};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,10 +230,10 @@ pub mod information_panel;
 mod modals;
 
 pub use config::{
-    FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, FileDialogStorage, IconFilter,
-    KeyBinding, OpeningMode, QuickAccess, QuickAccessPath,
+    FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, IconFilter, KeyBinding, OpeningMode,
+    QuickAccess, QuickAccessPath,
 };
 pub use data::{DirectoryEntry, Disk, Disks, Metadata, UserDirectories};
-pub use file_dialog::{DialogMode, DialogState, FileDialog};
+pub use file_dialog::{DialogMode, DialogState, FileDialog, FileDialogStorage};
 
 pub use file_system::{FileSystem, NativeFileSystem};


### PR DESCRIPTION
Removed `FileDialogStorage` from `FileDialogConfig` because I find it more user-friendly and logical to have the configuration and storage separate. Typically, there's only one `FileDialogStorage` in the application, although you may want to use several different configurations. If the storage is in the configuration, you'll need access to the file dialog wherever you create a configuration.