### PR TITLE
feat: add shortcut add_file_filter_extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added ability to open path context menu from a segment inside the navigation bar [#253](https://github.com/fluxxcode/egui-file-dialog/pull/253)
 - Added `FileDialog::set_operation_id` to set the ID of the operation for which the dialog is currently being used after opening it [#257](https://github.com/jannistpl/egui-file-dialog/pull/257)
 - Added ability to rename a pinnend folder via its context menu [#258](https://github.com/jannistpl/egui-file-dialog/pull/258)
+- Added shortcut methods `FileDialog::add_file_filter_extensions` and `FileDialogConfig::add_file_filter_extensions` which allow adding a filter matching specific file extensions [#263](https://github.com/jannistpl/egui-file-dialog/pull/263)
 
 ### ☢️ Deprecated
 

--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -20,10 +20,7 @@ impl MyApp {
                 s.add_path("📷  Media", "media");
                 s.add_path("📂  Source", "src");
             })
-            .add_file_filter(
-                "PNG files",
-                Arc::new(|p| p.extension().unwrap_or_default() == "png"),
-            )
+            .add_file_filter_extensions("Pictures", vec!["png", "jpg", "dds"])
             .add_file_filter(
                 "RS files",
                 Arc::new(|p| p.extension().unwrap_or_default() == "rs"),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -355,6 +355,35 @@ impl FileDialogConfig {
         self
     }
 
+    /// Shortctut method to add a file filter that matches specific extensions.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Display name of the filter
+    /// * `extensions` - The extensions of the files to be filtered
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use egui_file_dialog::FileDialog;
+    ///
+    /// FileDialog::new()
+    ///     .add_file_filter_extensions("Pictures", vec!["png", "jpg", "dds"])
+    ///     .add_file_filter_extensions("Rust files", vec!["rs", "toml", "lock"])
+    pub fn add_file_filter_extensions(self, name: &str, extensions: Vec<&'static str>) -> Self {
+        self.add_file_filter(
+            name,
+            Arc::new(move |p| {
+                let extension = p
+                    .extension()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default();
+                extensions.contains(&extension)
+            }),
+        )
+    }
+
     /// Adds a new file extension that the user can select in a dropdown widget when
     /// saving a file.
     ///

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -369,7 +369,7 @@ impl FileDialogConfig {
     ///
     /// FileDialog::new()
     ///     .add_file_filter_extensions("Pictures", vec!["png", "jpg", "dds"])
-    ///     .add_file_filter_extensions("Rust files", vec!["rs", "toml", "lock"])
+    ///     .add_file_filter_extensions("Rust files", vec!["rs", "toml", "lock"]);
     pub fn add_file_filter_extensions(self, name: &str, extensions: Vec<&'static str>) -> Self {
         self.add_file_filter(
             name,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -365,9 +365,9 @@ impl FileDialogConfig {
     /// # Examples
     ///
     /// ```
-    /// use egui_file_dialog::FileDialog;
+    /// use egui_file_dialog::FileDialogConfig;
     ///
-    /// FileDialog::new()
+    /// FileDialogConfig::default()
     ///     .add_file_filter_extensions("Pictures", vec!["png", "jpg", "dds"])
     ///     .add_file_filter_extensions("Rust files", vec!["rs", "toml", "lock"]);
     pub fn add_file_filter_extensions(self, name: &str, extensions: Vec<&'static str>) -> Self {

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -703,6 +703,26 @@ impl FileDialog {
         self
     }
 
+    /// Shortctut method to add a file filter that matches specific extensions.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Display name of the filter
+    /// * `extensions` - The extensions of the files to be filtered
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use egui_file_dialog::FileDialog;
+    ///
+    /// FileDialog::new()
+    ///     .add_file_filter_extensions("Pictures", vec!["png", "jpg", "dds"])
+    ///     .add_file_filter_extensions("Rust files", vec!["rs", "toml", "lock"])
+    pub fn add_file_filter_extensions(mut self, name: &str, extensions: Vec<&'static str>) -> Self {
+        self.config = self.config.add_file_filter_extensions(name, extensions);
+        self
+    }
+
     /// Name of the file filter to be selected by default.
     ///
     /// No file filter is selected if there is no file filter with that name.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -717,7 +717,7 @@ impl FileDialog {
     ///
     /// FileDialog::new()
     ///     .add_file_filter_extensions("Pictures", vec!["png", "jpg", "dds"])
-    ///     .add_file_filter_extensions("Rust files", vec!["rs", "toml", "lock"])
+    ///     .add_file_filter_extensions("Rust files", vec!["rs", "toml", "lock"]);
     pub fn add_file_filter_extensions(mut self, name: &str, extensions: Vec<&'static str>) -> Self {
         self.config = self.config.add_file_filter_extensions(name, extensions);
         self


### PR DESCRIPTION
Added new shortcut methods `FileDialog::add_file_filter_extensions` and `FileDialogConfig::add_file_filter_extensions`  which allow adding a filter matching specific file extensions.

Example:
```rust
FileDialog::new()
    .add_file_filter_extensions("Pictures", vec!["png", "jpg", "dds"]);
```

Closes #261 