### PR TITLE
fix: package include and exclude fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ repository = "https://github.com/jannistpl/egui-file-dialog"
 homepage = "https://github.com/jannistpl/egui-file-dialog"
 readme = "README.md"
 license = "MIT"
-exclude = ["media/", ".github/"]
-include = ["media/readme/"]
+exclude = ["media/", "!media/readme/", ".github/"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Include and exclude fields have been corrected, as currently only the fields specified in the include directive were included. All other files, including the source, were incorrectly excluded.