### PR TITLE
Create directory dialog uses correct file system

### DIFF
--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -281,6 +281,7 @@ impl FileDialog {
     pub fn with_config(config: FileDialogConfig) -> Self {
         let mut obj = Self::new();
         *obj.config_mut() = config;
+        obj.create_directory_dialog = CreateDirectoryDialog::from_filesystem(obj.config.file_system.clone());
         obj
     }
 
@@ -290,6 +291,7 @@ impl FileDialog {
         let mut obj = Self::new();
         obj.config.initial_directory = file_system.current_dir().unwrap_or_default();
         obj.config.file_system = file_system;
+        obj.create_directory_dialog = CreateDirectoryDialog::from_filesystem(obj.config.file_system.clone());
         obj
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -281,7 +281,8 @@ impl FileDialog {
     pub fn with_config(config: FileDialogConfig) -> Self {
         let mut obj = Self::new();
         *obj.config_mut() = config;
-        obj.create_directory_dialog = CreateDirectoryDialog::from_filesystem(obj.config.file_system.clone());
+        obj.create_directory_dialog =
+            CreateDirectoryDialog::from_filesystem(obj.config.file_system.clone());
         obj
     }
 
@@ -291,7 +292,8 @@ impl FileDialog {
         let mut obj = Self::new();
         obj.config.initial_directory = file_system.current_dir().unwrap_or_default();
         obj.config.file_system = file_system;
-        obj.create_directory_dialog = CreateDirectoryDialog::from_filesystem(obj.config.file_system.clone());
+        obj.create_directory_dialog =
+            CreateDirectoryDialog::from_filesystem(obj.config.file_system.clone());
         obj
     }
 


### PR DESCRIPTION
While testing custom file systems, I realized that the user is unable to create directories properly because the CreateDirectoryDialog always holds a reference to NativeFileSystem. This solves the problem by making sure that the dialog is updated when FileDialog is created from filesystem or config