### PR TITLE
refactor!: update state to be borrowed

### DIFF
--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1155,8 +1155,8 @@ impl FileDialog {
     }
 
     /// Returns the state the dialog is currently in.
-    pub fn state(&self) -> DialogState {
-        self.state.clone()
+    pub const fn state(&self) -> &DialogState {
+        &self.state
     }
 
     /// Get the window Id


### PR DESCRIPTION
Updated `FileDialog::state` to borrow the file dialog's state instead of cloning it.

Closes #281 