### PR TITLE
fix!: prevent user data from being cleared when file dialog is reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+### 🚨 Breaking Changes
+
 - Updated `FileDialog::state` to borrow the file dialog's state instead of cloning it [#282](https://github.com/jannistpl/egui-file-dialog/pull/282)
+- Prevent user data from being cleared when file dialog is reset [#285](https://github.com/jannistpl/egui-file-dialog/pull/285)
 
 ## 2025-07-10 - v0.11.0 - egui update and QoL changes
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -3101,12 +3101,15 @@ impl FileDialog {
     }
 
     /// Resets the dialog to use default values.
-    /// Configuration variables are retained.
+    /// The user data and configuration variables are retained.
     fn reset(&mut self) {
+        let user_data = std::mem::take(&mut self.user_data);
         let storage = self.storage.clone();
         let config = self.config.clone();
+
         *self = Self::with_config(config);
         self.storage = storage;
+        self.user_data = user_data;
     }
 
     /// Refreshes the dialog.


### PR DESCRIPTION
This MR fixes the unexpected behavior that user data is deleted when the file dialog is reset.

Closes #284 