### PR TITLE
Fix compilation on i686-pc-windows-msvc and i686-win7-windows-msvc

### DIFF
--- a/src/data/disks.rs
+++ b/src/data/disks.rs
@@ -153,6 +153,7 @@ fn gen_display_name(name: &str, mount_point: &str) -> String {
 
 #[cfg(windows)]
 fn load_disks(canonicalize_paths: bool) -> Vec<Disk> {
+    #![allow(unused_mut)]
     let mut disks: Vec<Disk> = sysinfo::Disks::new_with_refreshed_list()
         .iter()
         .map(|d| Disk::from_sysinfo_disk(d, canonicalize_paths))


### PR DESCRIPTION
The lines
```rust
extern "C" {
    pub fn GetLogicalDrives() -> u32;
}
```

cause the compilation on windows 32bit to fail


[example-compilation-log.txt](https://github.com/user-attachments/files/23142190/example-compilation-log.txt)
