### PR TITLE
Add open_directory_filter to skip navigating into matching directories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ egui-file-dialog = { path = "." , features = ["information_view"] }
 egui_extras = { version = "0.33", features = ["all_loaders"] }
 # required by the egui loaders
 image = { version = "0.25.5", features = ["bmp", "jpeg", "gif", "png", "tiff", "rayon"] }
+tempdir = "0.3"
 
 [features]
 default = ["serde", "default_fonts"]

--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -1,8 +1,7 @@
-use std::path::PathBuf;
-use std::sync::Arc;
+use std::path::{Path, PathBuf};
 
 use eframe::egui;
-use egui_file_dialog::{DialogMode, FileDialog};
+use egui_file_dialog::{DialogMode, FileDialog, Filter};
 
 struct MyApp {
     file_dialog: FileDialog,
@@ -24,11 +23,11 @@ impl MyApp {
             .add_file_filter_extensions("Pictures", vec!["png", "jpg", "dds"])
             .add_file_filter(
                 "RS files",
-                Arc::new(|p| p.extension().unwrap_or_default() == "rs"),
+                Filter::new(|p: &Path| p.extension().unwrap_or_default() == "rs"),
             )
             .add_file_filter(
                 "TOML files",
-                Arc::new(|p| p.extension().unwrap_or_default() == "toml"),
+                Filter::new(|p: &Path| p.extension().unwrap_or_default() == "toml"),
             )
             .add_save_extension("Picture", "png")
             .add_save_extension("Rust Source File", "rs")

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -243,6 +243,12 @@ pub struct FileDialogConfig {
     pub show_devices: bool,
     /// If the Removable Devices section in the left sidebar should be visible.
     pub show_removable_devices: bool,
+
+    /// Optional predicate called when the user activates a directory entry
+    /// (single-click submit via the Open button or double-click).
+    /// Return `true` to navigate *into* the directory (default behaviour);
+    /// return `false` to submit the directory as the picked path instead.
+    pub open_directory_filter: Option<DebugFilter>,
 }
 
 impl Default for FileDialogConfig {
@@ -332,6 +338,8 @@ impl FileDialogConfig {
             show_places: true,
             show_devices: true,
             show_removable_devices: true,
+
+            open_directory_filter: None,
 
             file_system,
         }
@@ -511,6 +519,17 @@ impl FileDialogConfig {
 
 /// Function that returns true if the specific item matches the filter.
 pub type Filter<T> = Arc<dyn Fn(&T) -> bool + Send + Sync>;
+
+/// Wrapper around `Filter<Path>` that provides a `Debug` implementation.
+/// Used for fields on `FileDialogConfig` that hold a `Filter<Path>`.
+#[derive(Clone)]
+pub struct DebugFilter(pub Filter<Path>);
+
+impl std::fmt::Debug for DebugFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DebugFilter(..)")
+    }
+}
 
 /// Defines a specific file filter that the user can select from a dropdown.
 #[derive(Clone)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -122,6 +122,11 @@ pub struct FileDialogConfig {
     pub load_via_thread: bool,
     /// If we should truncate the filenames in the middle
     pub truncate_filenames: bool,
+    /// Optional predicate called when the user activates a directory entry
+    /// (single-click submit via the Open button or double-click).
+    /// Return `true` to navigate *into* the directory (default behaviour);
+    /// return `false` to submit the directory as the picked path instead.
+    pub open_directory_filter: Option<Filter<Path>>,
 
     /// The icon that is used to display error messages.
     pub err_icon: String,
@@ -243,12 +248,6 @@ pub struct FileDialogConfig {
     pub show_devices: bool,
     /// If the Removable Devices section in the left sidebar should be visible.
     pub show_removable_devices: bool,
-
-    /// Optional predicate called when the user activates a directory entry
-    /// (single-click submit via the Open button or double-click).
-    /// Return `true` to navigate *into* the directory (default behaviour);
-    /// return `false` to submit the directory as the picked path instead.
-    pub open_directory_filter: Option<DebugFilter>,
 }
 
 impl Default for FileDialogConfig {
@@ -280,6 +279,7 @@ impl FileDialogConfig {
             load_via_thread: true,
 
             truncate_filenames: true,
+            open_directory_filter: None,
 
             err_icon: String::from("⚠"),
             warn_icon: String::from("⚠"),
@@ -339,8 +339,6 @@ impl FileDialogConfig {
             show_devices: true,
             show_removable_devices: true,
 
-            open_directory_filter: None,
-
             file_system,
         }
     }
@@ -361,16 +359,16 @@ impl FileDialogConfig {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::Arc;
-    /// use egui_file_dialog::FileDialogConfig;
+    /// use std::path::Path;
+    /// use egui_file_dialog::{FileDialogConfig, Filter};
     ///
     /// let config = FileDialogConfig::default()
     ///     .add_file_filter(
     ///         "PNG files",
-    ///         Arc::new(|path| path.extension().unwrap_or_default() == "png"))
+    ///         Filter::new(|path: &Path| path.extension().unwrap_or_default() == "png"))
     ///     .add_file_filter(
     ///         "JPG files",
-    ///         Arc::new(|path| path.extension().unwrap_or_default() == "jpg"));
+    ///         Filter::new(|path: &Path| path.extension().unwrap_or_default() == "jpg"));
     /// ```
     pub fn add_file_filter(mut self, name: &str, filter: Filter<Path>) -> Self {
         let id = egui::Id::new(name);
@@ -408,7 +406,7 @@ impl FileDialogConfig {
     pub fn add_file_filter_extensions(self, name: &str, extensions: Vec<&'static str>) -> Self {
         self.add_file_filter(
             name,
-            Arc::new(move |p| {
+            Filter::new(move |p: &Path| {
                 let extension = p
                     .extension()
                     .unwrap_or_default()
@@ -469,14 +467,14 @@ impl FileDialogConfig {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::Arc;
-    /// use egui_file_dialog::FileDialogConfig;
+    /// use std::path::Path;
+    /// use egui_file_dialog::{FileDialogConfig, Filter};
     ///
     /// let config = FileDialogConfig::default()
     ///     // .png files should use the "document with picture (U+1F5BB)" icon.
-    ///     .set_file_icon("🖻", Arc::new(|path| path.extension().unwrap_or_default() == "png"))
+    ///     .set_file_icon("🖻", Filter::new(|path: &Path| path.extension().unwrap_or_default() == "png"))
     ///     // .git directories should use the "web-github (U+E624)" icon.
-    ///     .set_file_icon("", Arc::new(|path| path.file_name().unwrap_or_default() == ".git"));
+    ///     .set_file_icon("", Filter::new(|path: &Path| path.file_name().unwrap_or_default() == ".git"));
     /// ```
     pub fn set_file_icon(mut self, icon: &str, filter: Filter<Path>) -> Self {
         self.file_icon_filters.push(IconFilter {
@@ -518,16 +516,24 @@ impl FileDialogConfig {
 }
 
 /// Function that returns true if the specific item matches the filter.
-pub type Filter<T> = Arc<dyn Fn(&T) -> bool + Send + Sync>;
+pub struct Filter<T: ?Sized>(pub(crate) Arc<dyn Fn(&T) -> bool + Send + Sync>);
 
-/// Wrapper around `Filter<Path>` that provides a `Debug` implementation.
-/// Used for fields on `FileDialogConfig` that hold a `Filter<Path>`.
-#[derive(Clone)]
-pub struct DebugFilter(pub Filter<Path>);
+impl<T: ?Sized> Clone for Filter<T> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
 
-impl std::fmt::Debug for DebugFilter {
+impl<T: ?Sized> Filter<T> {
+    /// Creates a new filter from a closure or function.
+    pub fn new(f: impl Fn(&T) -> bool + Send + Sync + 'static) -> Self {
+        Self(Arc::new(f))
+    }
+}
+
+impl<T: ?Sized> std::fmt::Debug for Filter<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "DebugFilter(..)")
+        write!(f, "Filter(..)")
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -122,11 +122,6 @@ pub struct FileDialogConfig {
     pub load_via_thread: bool,
     /// If we should truncate the filenames in the middle
     pub truncate_filenames: bool,
-    /// Optional predicate called when the user activates a directory entry
-    /// (single-click submit via the Open button or double-click).
-    /// Return `true` to navigate *into* the directory (default behaviour);
-    /// return `false` to submit the directory as the picked path instead.
-    pub open_directory_filter: Option<Filter<Path>>,
 
     /// The icon that is used to display error messages.
     pub err_icon: String,
@@ -157,6 +152,11 @@ pub struct FileDialogConfig {
     /// The icon used for the path edit input in the top panel.
     pub path_edit_icon: String,
 
+    /// Optional predicate called when the user activates a directory entry
+    /// (single-click submit via the Open button or double-click).
+    /// Return `true` to navigate *into* the directory (default behaviour);
+    /// return `false` to submit the directory as the picked path instead.
+    pub open_directory_filter: Option<Filter<Path>>,
     /// File filters presented to the user in a dropdown.
     pub file_filters: Vec<FileFilter>,
     /// Name of the file filter to be selected by default.
@@ -279,7 +279,6 @@ impl FileDialogConfig {
             load_via_thread: true,
 
             truncate_filenames: true,
-            open_directory_filter: None,
 
             err_icon: String::from("⚠"),
             warn_icon: String::from("⚠"),
@@ -296,6 +295,7 @@ impl FileDialogConfig {
             search_icon: String::from("🔍"),
             path_edit_icon: String::from("🖊"),
 
+            open_directory_filter: None,
             file_filters: Vec::new(),
             default_file_filter: None,
             save_extensions: Vec::new(),
@@ -375,7 +375,7 @@ impl FileDialogConfig {
 
         // Replace filter if a filter with the same name already exists.
         if let Some(item) = self.file_filters.iter_mut().find(|p| p.id == id) {
-            item.filter = filter.clone();
+            item.filter = filter;
             return self;
         }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -529,6 +529,11 @@ impl<T: ?Sized> Filter<T> {
     pub fn new(f: impl Fn(&T) -> bool + Send + Sync + 'static) -> Self {
         Self(Arc::new(f))
     }
+
+    /// Returns `true` if the item matches this filter.
+    pub(crate) fn matches(&self, item: &T) -> bool {
+        (self.0)(item)
+    }
 }
 
 impl<T: ?Sized> std::fmt::Debug for Filter<T> {

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -402,7 +402,7 @@ fn load_directory(
         }
 
         if let Some(file_filter) = &filter.file_filter {
-            if entry.is_file() && !(file_filter.filter)(entry.as_path()) {
+            if entry.is_file() && !(file_filter.filter.0)(entry.as_path()) {
                 continue;
             }
         }
@@ -441,7 +441,7 @@ fn load_directory(
 /// file icon filters.
 fn gen_path_icon(config: &FileDialogConfig, path: &Path, file_system: &dyn FileSystem) -> String {
     for def in &config.file_icon_filters {
-        if (def.filter)(path) {
+        if (def.filter.0)(path) {
             return def.icon.clone();
         }
     }

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -402,7 +402,7 @@ fn load_directory(
         }
 
         if let Some(file_filter) = &filter.file_filter {
-            if entry.is_file() && !(file_filter.filter.0)(entry.as_path()) {
+            if entry.is_file() && !file_filter.filter.matches(entry.as_path()) {
                 continue;
             }
         }
@@ -441,7 +441,7 @@ fn load_directory(
 /// file icon filters.
 fn gen_path_icon(config: &FileDialogConfig, path: &Path, file_system: &dyn FileSystem) -> String {
     for def in &config.file_icon_filters {
-        if (def.filter.0)(path) {
+        if def.filter.matches(path) {
             return def.icon.clone();
         }
     }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -3689,8 +3689,9 @@ const fn test() {
 
 #[cfg(test)]
 mod open_directory_filter_tests {
-    use super::*;
     use std::path::Path;
+
+    use super::*;
 
     #[test]
     fn filter_is_none_by_default() {
@@ -3752,25 +3753,28 @@ mod open_directory_filter_tests {
     /// contains a sentinel file (simulating the project-picker use-case).  We
     /// use a real temporary directory so the `exists()` call is meaningful.
     #[test]
-    fn filter_based_on_sentinel_file() {
+    fn filter_based_on_sentinel_file() -> Result<(), Box<dyn std::error::Error>> {
         use tempdir::TempDir;
-        let tmp = TempDir::new("egui_fd_test").expect("create tempdir");
+        let tmp = TempDir::new("egui_fd_test")?;
         let project_dir = tmp.path().join("project");
-        std::fs::create_dir_all(&project_dir).expect("create project dir");
+        std::fs::create_dir_all(&project_dir)?;
         let sentinel = project_dir.join("project.json");
-        std::fs::write(&sentinel, b"{}").expect("write sentinel");
+        std::fs::write(&sentinel, b"{}")?;
 
         let regular_dir = tmp.path().join("regular");
-        std::fs::create_dir_all(&regular_dir).expect("create regular dir");
+        std::fs::create_dir_all(&regular_dir)?;
 
         let mut dialog = FileDialog::new();
         // Mimic a project picker filter: navigate into dirs that are NOT projects.
-        dialog.set_open_directory_filter(Filter::new(|path: &Path| !path.join("project.json").exists()));
+        dialog.set_open_directory_filter(Filter::new(|path: &Path| {
+            !path.join("project.json").exists()
+        }));
 
         // Project directories should NOT be navigated into (filter → false → submit).
         assert!(!dialog.should_open_directory(&project_dir));
         // Regular directories should be navigated into normally.
         assert!(dialog.should_open_directory(&regular_dir));
         // tempdir auto-cleans on drop
+        Ok(())
     }
 }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -486,6 +486,22 @@ impl FileDialog {
         &mut self.config
     }
 
+    /// Sets a predicate called when a directory entry is activated (double-click
+    /// or Open-button click).  Return `true` to navigate into the directory
+    /// (the default); return `false` to submit it as the picked path instead.
+    pub fn set_open_directory_filter(
+        &mut self,
+        filter: impl Fn(&std::path::Path) -> bool + Send + Sync + 'static,
+    ) {
+        self.config.open_directory_filter =
+            Some(crate::config::DebugFilter(std::sync::Arc::new(filter)));
+    }
+
+    /// Clears any previously set `open_directory_filter`.
+    pub fn clear_open_directory_filter(&mut self) {
+        self.config.open_directory_filter = None;
+    }
+
     /// Sets the storage used by the file dialog.
     /// Storage includes all data that is persistently stored between multiple
     /// file dialog instances.
@@ -2616,8 +2632,19 @@ impl FileDialog {
         // Either open the directory or submit the dialog.
         if re.double_clicked() && !ui.input(|i| i.modifiers.command) {
             if item.is_dir() {
-                self.load_directory(&item.to_path_buf());
-                return true;
+                // If a filter is configured, check whether we should navigate
+                // into the directory or treat it as the picked path instead.
+                let should_open_dir = self
+                    .config
+                    .open_directory_filter
+                    .as_ref()
+                    .map_or(true, |f| (f.0)(item.as_path()));
+
+                if should_open_dir {
+                    self.load_directory(&item.to_path_buf());
+                    return true;
+                }
+                // Fall through to submit the directory as the picked path.
             }
 
             self.select_item(item);

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -197,106 +197,6 @@ pub struct FileDialog {
     rename_pinned_folder_request_focus: bool,
 }
 
-/// This tests if file dialog is send and sync.
-#[cfg(test)]
-const fn test_prop<T: Send + Sync>() {}
-
-#[test]
-const fn test() {
-    test_prop::<FileDialog>();
-}
-
-#[cfg(test)]
-mod open_directory_filter_tests {
-    use super::*;
-    use std::path::Path;
-
-    #[test]
-    fn filter_is_none_by_default() {
-        let dialog = FileDialog::new();
-        assert!(dialog.config.open_directory_filter.is_none());
-    }
-
-    #[test]
-    fn set_open_directory_filter_stores_filter() {
-        let mut dialog = FileDialog::new();
-        dialog.set_open_directory_filter(|_: &Path| false);
-        assert!(dialog.config.open_directory_filter.is_some());
-    }
-
-    #[test]
-    fn clear_open_directory_filter_removes_filter() {
-        let mut dialog = FileDialog::new();
-        dialog.set_open_directory_filter(|_: &Path| false);
-        assert!(dialog.config.open_directory_filter.is_some());
-        dialog.clear_open_directory_filter();
-        assert!(dialog.config.open_directory_filter.is_none());
-    }
-
-    /// When no filter is set, the dialog should always navigate into directories
-    /// (the original default behaviour).
-    #[test]
-    fn no_filter_always_navigates() {
-        let dialog = FileDialog::new();
-        assert!(dialog.should_open_directory(Path::new("/any/dir")));
-    }
-
-    /// A filter that returns `false` (do not navigate) should prevent navigation.
-    #[test]
-    fn filter_returning_false_prevents_navigation() {
-        let mut dialog = FileDialog::new();
-        dialog.set_open_directory_filter(|_: &Path| false);
-        assert!(!dialog.should_open_directory(Path::new("/any/dir")));
-    }
-
-    /// A filter that returns `true` (navigate) should allow navigation.
-    #[test]
-    fn filter_returning_true_allows_navigation() {
-        let mut dialog = FileDialog::new();
-        dialog.set_open_directory_filter(|_: &Path| true);
-        assert!(dialog.should_open_directory(Path::new("/any/dir")));
-    }
-
-    /// After clearing a filter, navigation is allowed again for every path.
-    #[test]
-    fn cleared_filter_restores_default_navigation() {
-        let mut dialog = FileDialog::new();
-        dialog.set_open_directory_filter(|_: &Path| false);
-        assert!(!dialog.should_open_directory(Path::new("/any/dir")));
-        dialog.clear_open_directory_filter();
-        assert!(dialog.should_open_directory(Path::new("/any/dir")));
-    }
-
-    /// A path-sensitive filter: navigation is blocked only when the directory
-    /// contains a sentinel file (simulating the project-picker use-case).  We
-    /// use a real temporary directory so the `exists()` call is meaningful.
-    #[test]
-    fn filter_based_on_sentinel_file() {
-        let tmp = std::env::temp_dir();
-        let project_dir = tmp.join("egui_fd_test_project_dir");
-        let _ = std::fs::create_dir_all(&project_dir);
-        let sentinel = project_dir.join("project.json");
-        let _ = std::fs::write(&sentinel, b"{}");
-
-        let regular_dir = tmp.join("egui_fd_test_regular_dir");
-        let _ = std::fs::create_dir_all(&regular_dir);
-
-        let mut dialog = FileDialog::new();
-        // Mimic a project picker filter: navigate into dirs that are NOT projects.
-        dialog.set_open_directory_filter(|path: &Path| !path.join("project.json").exists());
-
-        // Project directories should NOT be navigated into (filter → false → submit).
-        assert!(!dialog.should_open_directory(&project_dir));
-        // Regular directories should be navigated into normally.
-        assert!(dialog.should_open_directory(&regular_dir));
-
-        // Cleanup
-        let _ = std::fs::remove_file(&sentinel);
-        let _ = std::fs::remove_dir(&project_dir);
-        let _ = std::fs::remove_dir(&regular_dir);
-    }
-}
-
 impl Default for FileDialog {
     /// Creates a new file dialog instance with default values.
     fn default() -> Self {
@@ -3779,5 +3679,105 @@ impl FileDialog {
         if self.mode == DialogMode::SaveFile {
             self.file_name_input_error = self.validate_file_name_input();
         }
+    }
+}
+
+/// This tests if file dialog is send and sync.
+#[cfg(test)]
+const fn test_prop<T: Send + Sync>() {}
+
+#[test]
+const fn test() {
+    test_prop::<FileDialog>();
+}
+
+#[cfg(test)]
+mod open_directory_filter_tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn filter_is_none_by_default() {
+        let dialog = FileDialog::new();
+        assert!(dialog.config.open_directory_filter.is_none());
+    }
+
+    #[test]
+    fn set_open_directory_filter_stores_filter() {
+        let mut dialog = FileDialog::new();
+        dialog.set_open_directory_filter(|_: &Path| false);
+        assert!(dialog.config.open_directory_filter.is_some());
+    }
+
+    #[test]
+    fn clear_open_directory_filter_removes_filter() {
+        let mut dialog = FileDialog::new();
+        dialog.set_open_directory_filter(|_: &Path| false);
+        assert!(dialog.config.open_directory_filter.is_some());
+        dialog.clear_open_directory_filter();
+        assert!(dialog.config.open_directory_filter.is_none());
+    }
+
+    /// When no filter is set, the dialog should always navigate into directories
+    /// (the original default behaviour).
+    #[test]
+    fn no_filter_always_navigates() {
+        let dialog = FileDialog::new();
+        assert!(dialog.should_open_directory(Path::new("/any/dir")));
+    }
+
+    /// A filter that returns `false` (do not navigate) should prevent navigation.
+    #[test]
+    fn filter_returning_false_prevents_navigation() {
+        let mut dialog = FileDialog::new();
+        dialog.set_open_directory_filter(|_: &Path| false);
+        assert!(!dialog.should_open_directory(Path::new("/any/dir")));
+    }
+
+    /// A filter that returns `true` (navigate) should allow navigation.
+    #[test]
+    fn filter_returning_true_allows_navigation() {
+        let mut dialog = FileDialog::new();
+        dialog.set_open_directory_filter(|_: &Path| true);
+        assert!(dialog.should_open_directory(Path::new("/any/dir")));
+    }
+
+    /// After clearing a filter, navigation is allowed again for every path.
+    #[test]
+    fn cleared_filter_restores_default_navigation() {
+        let mut dialog = FileDialog::new();
+        dialog.set_open_directory_filter(|_: &Path| false);
+        assert!(!dialog.should_open_directory(Path::new("/any/dir")));
+        dialog.clear_open_directory_filter();
+        assert!(dialog.should_open_directory(Path::new("/any/dir")));
+    }
+
+    /// A path-sensitive filter: navigation is blocked only when the directory
+    /// contains a sentinel file (simulating the project-picker use-case).  We
+    /// use a real temporary directory so the `exists()` call is meaningful.
+    #[test]
+    fn filter_based_on_sentinel_file() {
+        let tmp = std::env::temp_dir();
+        let project_dir = tmp.join("egui_fd_test_project_dir");
+        let _ = std::fs::create_dir_all(&project_dir);
+        let sentinel = project_dir.join("project.json");
+        let _ = std::fs::write(&sentinel, b"{}");
+
+        let regular_dir = tmp.join("egui_fd_test_regular_dir");
+        let _ = std::fs::create_dir_all(&regular_dir);
+
+        let mut dialog = FileDialog::new();
+        // Mimic a project picker filter: navigate into dirs that are NOT projects.
+        dialog.set_open_directory_filter(|path: &Path| !path.join("project.json").exists());
+
+        // Project directories should NOT be navigated into (filter → false → submit).
+        assert!(!dialog.should_open_directory(&project_dir));
+        // Regular directories should be navigated into normally.
+        assert!(dialog.should_open_directory(&regular_dir));
+
+        // Cleanup
+        let _ = std::fs::remove_file(&sentinel);
+        let _ = std::fs::remove_dir(&project_dir);
+        let _ = std::fs::remove_dir(&regular_dir);
     }
 }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -480,27 +480,13 @@ impl FileDialog {
     /// Sets a predicate called when a directory entry is activated (double-click
     /// or Open-button click).  Return `true` to navigate into the directory
     /// (the default); return `false` to submit it as the picked path instead.
-    pub fn set_open_directory_filter(
-        &mut self,
-        filter: impl Fn(&std::path::Path) -> bool + Send + Sync + 'static,
-    ) {
-        self.config.open_directory_filter =
-            Some(crate::config::DebugFilter(std::sync::Arc::new(filter)));
+    pub fn set_open_directory_filter(&mut self, filter: Filter<Path>) {
+        self.config.open_directory_filter = Some(filter);
     }
 
     /// Clears any previously set `open_directory_filter`.
     pub fn clear_open_directory_filter(&mut self) {
         self.config.open_directory_filter = None;
-    }
-
-    /// Returns `true` if the given directory should be navigated into,
-    /// or `false` if it should be submitted as the picked path instead.
-    /// When no filter is set, this always returns `true` (the default behaviour).
-    fn should_open_directory(&self, path: &std::path::Path) -> bool {
-        self.config
-            .open_directory_filter
-            .as_ref()
-            .is_none_or(|f| (f.0)(path))
     }
 
     /// Sets the storage used by the file dialog.
@@ -732,16 +718,16 @@ impl FileDialog {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::Arc;
-    /// use egui_file_dialog::FileDialog;
+    /// use std::path::Path;
+    /// use egui_file_dialog::{FileDialog, Filter};
     ///
     /// FileDialog::new()
     ///     .add_file_filter(
     ///         "PNG files",
-    ///         Arc::new(|path| path.extension().unwrap_or_default() == "png"))
+    ///         Filter::new(|path: &Path| path.extension().unwrap_or_default() == "png"))
     ///     .add_file_filter(
     ///         "JPG files",
-    ///         Arc::new(|path| path.extension().unwrap_or_default() == "jpg"));
+    ///         Filter::new(|path: &Path| path.extension().unwrap_or_default() == "jpg"));
     /// ```
     pub fn add_file_filter(mut self, name: &str, filter: Filter<Path>) -> Self {
         self.config = self.config.add_file_filter(name, filter);
@@ -821,14 +807,14 @@ impl FileDialog {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::Arc;
-    /// use egui_file_dialog::FileDialog;
+    /// use std::path::Path;
+    /// use egui_file_dialog::{FileDialog, Filter};
     ///
     /// FileDialog::new()
     ///     // .png files should use the "document with picture (U+1F5BB)" icon.
-    ///     .set_file_icon("🖻", Arc::new(|path| path.extension().unwrap_or_default() == "png"))
+    ///     .set_file_icon("🖻", Filter::new(|path: &Path| path.extension().unwrap_or_default() == "png"))
     ///     // .git directories should use the "web-github (U+E624)" icon.
-    ///     .set_file_icon("", Arc::new(|path| path.file_name().unwrap_or_default() == ".git"));
+    ///     .set_file_icon("", Filter::new(|path: &Path| path.file_name().unwrap_or_default() == ".git"));
     /// ```
     pub fn set_file_icon(mut self, icon: &str, filter: Filter<std::path::Path>) -> Self {
         self.config = self.config.set_file_icon(icon, filter);
@@ -3680,6 +3666,16 @@ impl FileDialog {
             self.file_name_input_error = self.validate_file_name_input();
         }
     }
+
+    /// Returns `true` if the given directory should be navigated into,
+    /// or `false` if it should be submitted as the picked path instead.
+    /// When no filter is set, this always returns `true` (the default behaviour).
+    fn should_open_directory(&self, path: &std::path::Path) -> bool {
+        self.config
+            .open_directory_filter
+            .as_ref()
+            .is_none_or(|f| (f.0)(path))
+    }
 }
 
 /// This tests if file dialog is send and sync.
@@ -3705,14 +3701,14 @@ mod open_directory_filter_tests {
     #[test]
     fn set_open_directory_filter_stores_filter() {
         let mut dialog = FileDialog::new();
-        dialog.set_open_directory_filter(|_: &Path| false);
+        dialog.set_open_directory_filter(Filter::new(|_: &Path| false));
         assert!(dialog.config.open_directory_filter.is_some());
     }
 
     #[test]
     fn clear_open_directory_filter_removes_filter() {
         let mut dialog = FileDialog::new();
-        dialog.set_open_directory_filter(|_: &Path| false);
+        dialog.set_open_directory_filter(Filter::new(|_: &Path| false));
         assert!(dialog.config.open_directory_filter.is_some());
         dialog.clear_open_directory_filter();
         assert!(dialog.config.open_directory_filter.is_none());
@@ -3730,7 +3726,7 @@ mod open_directory_filter_tests {
     #[test]
     fn filter_returning_false_prevents_navigation() {
         let mut dialog = FileDialog::new();
-        dialog.set_open_directory_filter(|_: &Path| false);
+        dialog.set_open_directory_filter(Filter::new(|_: &Path| false));
         assert!(!dialog.should_open_directory(Path::new("/any/dir")));
     }
 
@@ -3738,7 +3734,7 @@ mod open_directory_filter_tests {
     #[test]
     fn filter_returning_true_allows_navigation() {
         let mut dialog = FileDialog::new();
-        dialog.set_open_directory_filter(|_: &Path| true);
+        dialog.set_open_directory_filter(Filter::new(|_: &Path| true));
         assert!(dialog.should_open_directory(Path::new("/any/dir")));
     }
 
@@ -3746,7 +3742,7 @@ mod open_directory_filter_tests {
     #[test]
     fn cleared_filter_restores_default_navigation() {
         let mut dialog = FileDialog::new();
-        dialog.set_open_directory_filter(|_: &Path| false);
+        dialog.set_open_directory_filter(Filter::new(|_: &Path| false));
         assert!(!dialog.should_open_directory(Path::new("/any/dir")));
         dialog.clear_open_directory_filter();
         assert!(dialog.should_open_directory(Path::new("/any/dir")));
@@ -3757,27 +3753,24 @@ mod open_directory_filter_tests {
     /// use a real temporary directory so the `exists()` call is meaningful.
     #[test]
     fn filter_based_on_sentinel_file() {
-        let tmp = std::env::temp_dir();
-        let project_dir = tmp.join("egui_fd_test_project_dir");
-        let _ = std::fs::create_dir_all(&project_dir);
+        use tempdir::TempDir;
+        let tmp = TempDir::new("egui_fd_test").expect("create tempdir");
+        let project_dir = tmp.path().join("project");
+        std::fs::create_dir_all(&project_dir).expect("create project dir");
         let sentinel = project_dir.join("project.json");
-        let _ = std::fs::write(&sentinel, b"{}");
+        std::fs::write(&sentinel, b"{}").expect("write sentinel");
 
-        let regular_dir = tmp.join("egui_fd_test_regular_dir");
-        let _ = std::fs::create_dir_all(&regular_dir);
+        let regular_dir = tmp.path().join("regular");
+        std::fs::create_dir_all(&regular_dir).expect("create regular dir");
 
         let mut dialog = FileDialog::new();
         // Mimic a project picker filter: navigate into dirs that are NOT projects.
-        dialog.set_open_directory_filter(|path: &Path| !path.join("project.json").exists());
+        dialog.set_open_directory_filter(Filter::new(|path: &Path| !path.join("project.json").exists()));
 
         // Project directories should NOT be navigated into (filter → false → submit).
         assert!(!dialog.should_open_directory(&project_dir));
         // Regular directories should be navigated into normally.
         assert!(dialog.should_open_directory(&regular_dir));
-
-        // Cleanup
-        let _ = std::fs::remove_file(&sentinel);
-        let _ = std::fs::remove_dir(&project_dir);
-        let _ = std::fs::remove_dir(&regular_dir);
+        // tempdir auto-cleans on drop
     }
 }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -206,6 +206,97 @@ const fn test() {
     test_prop::<FileDialog>();
 }
 
+#[cfg(test)]
+mod open_directory_filter_tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn filter_is_none_by_default() {
+        let dialog = FileDialog::new();
+        assert!(dialog.config.open_directory_filter.is_none());
+    }
+
+    #[test]
+    fn set_open_directory_filter_stores_filter() {
+        let mut dialog = FileDialog::new();
+        dialog.set_open_directory_filter(|_: &Path| false);
+        assert!(dialog.config.open_directory_filter.is_some());
+    }
+
+    #[test]
+    fn clear_open_directory_filter_removes_filter() {
+        let mut dialog = FileDialog::new();
+        dialog.set_open_directory_filter(|_: &Path| false);
+        assert!(dialog.config.open_directory_filter.is_some());
+        dialog.clear_open_directory_filter();
+        assert!(dialog.config.open_directory_filter.is_none());
+    }
+
+    /// When no filter is set, the dialog should always navigate into directories
+    /// (the original default behaviour).
+    #[test]
+    fn no_filter_always_navigates() {
+        let dialog = FileDialog::new();
+        assert!(dialog.should_open_directory(Path::new("/any/dir")));
+    }
+
+    /// A filter that returns `false` (do not navigate) should prevent navigation.
+    #[test]
+    fn filter_returning_false_prevents_navigation() {
+        let mut dialog = FileDialog::new();
+        dialog.set_open_directory_filter(|_: &Path| false);
+        assert!(!dialog.should_open_directory(Path::new("/any/dir")));
+    }
+
+    /// A filter that returns `true` (navigate) should allow navigation.
+    #[test]
+    fn filter_returning_true_allows_navigation() {
+        let mut dialog = FileDialog::new();
+        dialog.set_open_directory_filter(|_: &Path| true);
+        assert!(dialog.should_open_directory(Path::new("/any/dir")));
+    }
+
+    /// After clearing a filter, navigation is allowed again for every path.
+    #[test]
+    fn cleared_filter_restores_default_navigation() {
+        let mut dialog = FileDialog::new();
+        dialog.set_open_directory_filter(|_: &Path| false);
+        assert!(!dialog.should_open_directory(Path::new("/any/dir")));
+        dialog.clear_open_directory_filter();
+        assert!(dialog.should_open_directory(Path::new("/any/dir")));
+    }
+
+    /// A path-sensitive filter: navigation is blocked only when the directory
+    /// contains a sentinel file (simulating the project-picker use-case).  We
+    /// use a real temporary directory so the `exists()` call is meaningful.
+    #[test]
+    fn filter_based_on_sentinel_file() {
+        let tmp = std::env::temp_dir();
+        let project_dir = tmp.join("egui_fd_test_project_dir");
+        let _ = std::fs::create_dir_all(&project_dir);
+        let sentinel = project_dir.join("project.json");
+        let _ = std::fs::write(&sentinel, b"{}");
+
+        let regular_dir = tmp.join("egui_fd_test_regular_dir");
+        let _ = std::fs::create_dir_all(&regular_dir);
+
+        let mut dialog = FileDialog::new();
+        // Mimic a project picker filter: navigate into dirs that are NOT projects.
+        dialog.set_open_directory_filter(|path: &Path| !path.join("project.json").exists());
+
+        // Project directories should NOT be navigated into (filter → false → submit).
+        assert!(!dialog.should_open_directory(&project_dir));
+        // Regular directories should be navigated into normally.
+        assert!(dialog.should_open_directory(&regular_dir));
+
+        // Cleanup
+        let _ = std::fs::remove_file(&sentinel);
+        let _ = std::fs::remove_dir(&project_dir);
+        let _ = std::fs::remove_dir(&regular_dir);
+    }
+}
+
 impl Default for FileDialog {
     /// Creates a new file dialog instance with default values.
     fn default() -> Self {
@@ -500,6 +591,16 @@ impl FileDialog {
     /// Clears any previously set `open_directory_filter`.
     pub fn clear_open_directory_filter(&mut self) {
         self.config.open_directory_filter = None;
+    }
+
+    /// Returns `true` if the given directory should be navigated into,
+    /// or `false` if it should be submitted as the picked path instead.
+    /// When no filter is set, this always returns `true` (the default behaviour).
+    fn should_open_directory(&self, path: &std::path::Path) -> bool {
+        self.config
+            .open_directory_filter
+            .as_ref()
+            .map_or(true, |f| (f.0)(path))
     }
 
     /// Sets the storage used by the file dialog.
@@ -2634,13 +2735,7 @@ impl FileDialog {
             if item.is_dir() {
                 // If a filter is configured, check whether we should navigate
                 // into the directory or treat it as the picked path instead.
-                let should_open_dir = self
-                    .config
-                    .open_directory_filter
-                    .as_ref()
-                    .map_or(true, |f| (f.0)(item.as_path()));
-
-                if should_open_dir {
+                if self.should_open_directory(item.as_path()) {
                     self.load_directory(&item.to_path_buf());
                     return true;
                 }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -3674,7 +3674,7 @@ impl FileDialog {
         self.config
             .open_directory_filter
             .as_ref()
-            .is_none_or(|f| (f.0)(path))
+            .is_none_or(|f| f.matches(path))
     }
 }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -600,7 +600,7 @@ impl FileDialog {
         self.config
             .open_directory_filter
             .as_ref()
-            .map_or(true, |f| (f.0)(path))
+            .is_none_or(|f| (f.0)(path))
     }
 
     /// Sets the storage used by the file dialog.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,8 +230,8 @@ pub mod information_panel;
 mod modals;
 
 pub use config::{
-    FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, Filter, IconFilter, KeyBinding, OpeningMode,
-    PinnedFolder, QuickAccess, QuickAccessPath,
+    FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, Filter, IconFilter, KeyBinding,
+    OpeningMode, PinnedFolder, QuickAccess, QuickAccessPath,
 };
 pub use data::{DirectoryEntry, Disk, Disks, Metadata, UserDirectories};
 pub use file_dialog::{DialogMode, DialogState, FileDialog, FileDialogStorage};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ pub mod information_panel;
 mod modals;
 
 pub use config::{
-    FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, IconFilter, KeyBinding, OpeningMode,
+    FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, Filter, IconFilter, KeyBinding, OpeningMode,
     PinnedFolder, QuickAccess, QuickAccessPath,
 };
 pub use data::{DirectoryEntry, Disk, Disks, Metadata, UserDirectories};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,9 +117,8 @@
 //!
 //! ```rust
 //! use std::path::PathBuf;
-//! use std::sync::Arc;
 //!
-//! use egui_file_dialog::FileDialog;
+//! use egui_file_dialog::{FileDialog, Filter};
 //!
 //! FileDialog::new()
 //!     .initial_directory(PathBuf::from("/path/to/app"))
@@ -138,21 +137,21 @@
 //!     // Markdown files should use the "document with text (U+1F5B9)" icon
 //!     .set_file_icon(
 //!         "🖹",
-//!         Arc::new(|path| path.extension().unwrap_or_default() == "md"),
+//!         Filter::new(|path: &std::path::Path| path.extension().unwrap_or_default() == "md"),
 //!     )
 //!     // .gitignore files should use the "web-github (U+E624)" icon
 //!     .set_file_icon(
-//!         "",
-//!         Arc::new(|path| path.file_name().unwrap_or_default() == ".gitignore"),
+//!         "",
+//!         Filter::new(|path: &std::path::Path| path.file_name().unwrap_or_default() == ".gitignore"),
 //!     )
 //!     // Add file filters the user can select in the bottom right
 //!     .add_file_filter(
 //!         "PNG files",
-//!         Arc::new(|p| p.extension().unwrap_or_default() == "png"),
+//!         Filter::new(|p: &std::path::Path| p.extension().unwrap_or_default() == "png"),
 //!     )
 //!     .add_file_filter(
 //!         "Rust source files",
-//!         Arc::new(|p| p.extension().unwrap_or_default() == "rs"),
+//!         Filter::new(|p: &std::path::Path| p.extension().unwrap_or_default() == "rs"),
 //!     );
 //! ```
 //!


### PR DESCRIPTION
I'm building an app with Bevy that saves its state in project directories. I use the file dialog to choose which project directory to open. 

A feature that I was looking for was to have the file dialog not recurse into project directories, but if a given condition is met (like that directory containing a project.json file), to return that directory as the picked path. 

This is good for UX, as otherwise users might not choose the correct project directory root, but some subdirectory, causing an error. 

---

This PR adds an `open_directory_filter` option to `FileDialogConfig` that allows
callers to control which directories can be navigated into. When a directory
does not pass the filter, double-clicking it submits it as the selected
path instead of navigating into it.