### PR TITLE
fix: incorrect rendering order of modal background and file dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # egui-file-dialog changelog
 
+## Unreleased
+
+### 🐛 Bug Fixes
+
+- Fix incorrect rendering order of modal background and file dialog window [#332](https://github.com/jannistpl/egui-file-dialog/pull/332)
+
 ## 2026-06-26 - v0.14.0 - egui update, UI improvements and QoL changes
 
 ### 🚨 Breaking Changes

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -196,6 +196,12 @@ pub struct FileDialog {
     /// If the text input of the pinned folder being renamed should request focus in
     /// the next frame.
     rename_pinned_folder_request_focus: bool,
+
+    /// Whether the rendering order of the modal background and the file dialog
+    /// should be initialized in the next frame. This causes the modal background
+    /// to be moved to the foreground first, followed by the file dialog window
+    /// in the subsequent frame.
+    init_rendering_oder: bool,
 }
 
 impl Default for FileDialog {
@@ -268,6 +274,8 @@ impl FileDialog {
 
             rename_pinned_folder: None,
             rename_pinned_folder_request_focus: false,
+
+            init_rendering_oder: true,
         }
     }
 
@@ -1262,11 +1270,6 @@ impl FileDialog {
     ) {
         let mut is_open = true;
 
-        if self.config.as_modal {
-            let re = self.ui_update_modal_background(ctx);
-            ctx.move_to_top(re.response.layer_id);
-        }
-
         let re = self.create_window(&mut is_open).show(ctx, |ui| {
             if !self.modals.is_empty() {
                 self.ui_update_modals(ui);
@@ -1321,7 +1324,21 @@ impl FileDialog {
         });
 
         if self.config.as_modal {
-            if let Some(inner_response) = re {
+            let modal_re = self.ui_update_modal_background(ctx);
+
+            // This makes sure the rendering order for the modal background and the
+            // file dialog is initialized in separate frames. If both the modal
+            // background and the file dialog were moved to the foreground in the
+            // same frame, there would be no guarantee that the file dialog would
+            // actually appear in front of the modal background, as the internal
+            // ordering is preserved. In rare cases, this could result in an
+            // unusable file dialog.
+            // To prevent this, we first move the modal background to the top and then
+            // the file dialog window in the frame afterwards.
+            if self.init_rendering_oder {
+                ctx.move_to_top(modal_re.response.layer_id);
+                self.init_rendering_oder = false;
+            } else if let Some(inner_response) = re {
                 ctx.move_to_top(inner_response.response.layer_id);
             }
         }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -201,7 +201,7 @@ pub struct FileDialog {
     /// should be initialized in the next frame. This causes the modal background
     /// to be moved to the foreground first, followed by the file dialog window
     /// in the subsequent frame.
-    init_rendering_oder: bool,
+    init_rendering_order: bool,
 }
 
 impl Default for FileDialog {
@@ -275,7 +275,7 @@ impl FileDialog {
             rename_pinned_folder: None,
             rename_pinned_folder_request_focus: false,
 
-            init_rendering_oder: true,
+            init_rendering_order: true,
         }
     }
 
@@ -1335,9 +1335,9 @@ impl FileDialog {
             // unusable file dialog.
             // To prevent this, we first move the modal background to the top and then
             // the file dialog window in the frame afterwards.
-            if self.init_rendering_oder {
+            if self.init_rendering_order {
                 ctx.move_to_top(modal_re.response.layer_id);
-                self.init_rendering_oder = false;
+                self.init_rendering_order = false;
             } else if let Some(inner_response) = re {
                 ctx.move_to_top(inner_response.response.layer_id);
             }


### PR DESCRIPTION
This PR fixes an incorrect rendering order of the modal background and the file dalog window. This was an issue on rare cases, when egui window order persistence was enabled. This made the file dialog unusable, which could only be fixed by deleting the persistet egui data.
This PR makes sure that the file dialog window will always be on top of the modal background.